### PR TITLE
Fix concurrency bugs

### DIFF
--- a/DapperLike.SqlBulkCopy/ReflectionHelper.cs
+++ b/DapperLike.SqlBulkCopy/ReflectionHelper.cs
@@ -9,8 +9,8 @@ namespace DapperLike
 {
     internal static class ReflectionHelper
     {
-        private static readonly IDictionary<Type, Tuple<MemberInfo, string>[]> _columnMapCache = new ConcurrentDictionary<Type, Tuple<MemberInfo, string>[]>();
-        private static readonly IDictionary<Type, string> _tableNameCache = new ConcurrentDictionary<Type, string>();
+        private static readonly ConcurrentDictionary<Type, Tuple<MemberInfo, string>[]> _columnMapCache = new ConcurrentDictionary<Type, Tuple<MemberInfo, string>[]>();
+        private static readonly ConcurrentDictionary<Type, string> _tableNameCache = new ConcurrentDictionary<Type, string>();
 
         public static Tuple<MemberInfo, string>[] GetColumnMap(Type type)
         {
@@ -35,7 +35,7 @@ namespace DapperLike
 
             var columnMap = GetColumnMapImpl(type);
 
-            _columnMapCache.Add(type, columnMap);
+            _columnMapCache.TryAdd(type, columnMap);
             return columnMap;
         }
 
@@ -59,7 +59,7 @@ namespace DapperLike
             }
 
             var name = GetTableNameImpl(type);
-            _tableNameCache[type] = name;
+            _tableNameCache.TryAdd(type, name);
             return name;
         }
 


### PR DESCRIPTION
Hi,

in one of our projects we often get the following exception from this library:

```
System.ArgumentException: The key already existed in the dictionary.
   at System.Collections.Concurrent.ConcurrentDictionary`2.System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value)
   at DapperLike.ReflectionHelper.GetColumnMap(Type type)
   at DapperLike.SqlBulkCopyExtensions.BuildCustomTable[T](DataTable table, IEnumerable`1 data)
   at DapperLike.SqlBulkCopyExtensions.CreateTable[T](IEnumerable`1 data, String columnName)
   at DapperLike.SqlBulkCopyExtensions.BulkInsertAsyncImpl[T](SqlConnection sqlConnection, IEnumerable`1 data, String tableName, String columnName, SqlTransaction sqlTransaction, SqlBulkCopyOptions options, Nullable`1 commandTimeout)
```

after applying my changes the issue seems to be gone (at least it never happened again after). Probably since adding to the **ConcurrentDictionary** can now fail silently in case the element was already added from within another thread.